### PR TITLE
Fixes bug preventing fallback passcode

### DIFF
--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -317,7 +317,7 @@ options:NSNumericSearch] != NSOrderedAscending)
 }
 
 - (void)_setupFingerPrint {
-    if (!self.context && _allowUnlockWithTouchID) {
+    if (!self.context && _allowUnlockWithTouchID && !_useFallbackPasscode) {
         self.context = [[LAContext alloc] init];
         
         NSError *error = nil;


### PR DESCRIPTION
Currently when cancel is pressed on TouchID, the keypad briefly pops up but is again replaced by the TouchID controller. This is suboptimal as you can't quit an app if it keeps popping the controller up, and prevents entry when finger not available/dirty.
The issue appears to be that `-(void)_setupFingerPrint` is called each time auth fails, but there isn't any check for the `_useFallbackPasscode` bit, which is set later in this method on failure. This adds a check for that bit.
